### PR TITLE
Update 2024-02-16-counting-syscalls-in-python.markdown

### DIFF
--- a/_posts/2024-02-16-counting-syscalls-in-python.markdown
+++ b/_posts/2024-02-16-counting-syscalls-in-python.markdown
@@ -19,7 +19,7 @@ t = Tracer()
 
 t.start()
 print("Hello")
-trace = t.end()
+trace = t.stop()
 
 print(trace)
 # write(1, "Hello\n", 6) = 6 <0.000150s>
@@ -50,7 +50,7 @@ t = Tracer()
 
 t.start()
 import seaborn
-trace = t.end()
+trace = t.stop()
 
 print(len(trace))
 # 20462


### PR DESCRIPTION
Hi, I think the collector has `end`, but the tracer has the `stop` function?

https://github.com/s7nfo/Cirron/blob/dae20d2bd0be26f89212a6843860aadf394a397c/cirron/tracer.py#L144

Thanks!